### PR TITLE
fix: scale metadata profiler bars relative to n_total, not max_count

### DIFF
--- a/R/seurat_utils.R
+++ b/R/seurat_utils.R
@@ -313,7 +313,6 @@ build_metadata_profile <- function(meta, max_levels = 5L) {
   palette <- c("#4682B4", "#E07941", "#50A050", "#C75D8A", "#8E6FBF")
 
   # Build horizontal bars for top levels
-  max_count <- max(show_levels)
   bars <- vapply(seq_along(show_levels), function(i) {
     lbl <- names(show_levels)[i]
     cnt <- show_levels[i]

--- a/R/seurat_utils.R
+++ b/R/seurat_utils.R
@@ -318,7 +318,7 @@ build_metadata_profile <- function(meta, max_levels = 5L) {
     lbl <- names(show_levels)[i]
     cnt <- show_levels[i]
     pct <- round(cnt / n_total * 100, 1)
-    bar_w <- round(cnt / max_count * 100)
+    bar_w <- round(cnt / n_total * 100)
     color <- palette[((i - 1) %% length(palette)) + 1]
     paste0(
       "<div style='display:flex;align-items:center;gap:4px;margin:1px 0;font-size:11px;line-height:1.3;'>",

--- a/tests/testthat/test-build_metadata_profile.R
+++ b/tests/testthat/test-build_metadata_profile.R
@@ -136,6 +136,31 @@ test_that("build_metadata_profile handles an all-NA character column gracefully"
   expect_equal(result$Complete, "0%")
 })
 
+# -- Bar width proportionality (issue #13) ------------------------------------
+
+test_that("bar widths are proportional to n_total, not max_count", {
+  # 6 cells: A=3 (50%), B=2 (33.3%), C=1 (16.7%)
+  meta <- data.frame(
+    grp = c("A", "A", "A", "B", "B", "C"),
+    stringsAsFactors = FALSE
+  )
+
+  result <- build_metadata_profile(meta)
+  html <- result$Distribution
+
+  # Extract all width:XX% values from the bar divs
+  matches <- regmatches(
+    html, gregexpr("width:(\\d+)%", html)
+  )[[1]]
+  widths <- as.integer(gsub("width:|%", "", matches))
+
+
+  # A = 3/6 = 50%, B = 2/6 ≈ 33%, C = 1/6 ≈ 17%
+  expect_equal(widths[1], 50L)
+  expect_equal(widths[2], 33L)
+  expect_equal(widths[3], 17L)
+})
+
 # -- HTML output sanity -------------------------------------------------------
 
 test_that("build_metadata_profile Distribution column contains HTML", {


### PR DESCRIPTION
Bar widths in the metadata profiler were scaled relative to the largest category (max_count), making the largest category always full-width and inconsistent with the percentage labels shown. Scale to n_total so bar length matches the displayed percentage.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)